### PR TITLE
Added REI to the dependecty list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,22 +43,24 @@ dependencies {
 
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    modCompileOnly "me.shedaniel:RoughlyEnoughItems-api-fabric:19.0.806"
-    modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-fabric:19.0.806"
-    modCompileOnly "me.shedaniel:RoughlyEnoughItems-default-plugin-fabric:19.0.806"
-    modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-default-plugin-fabric:19.0.806"
+    modCompileOnly "me.shedaniel:RoughlyEnoughItems-api-fabric:${project.rei_version}"
+    modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"
+    modCompileOnly "me.shedaniel:RoughlyEnoughItems-default-plugin-fabric:${project.rei_version}"
+    modRuntimeOnly "me.shedaniel:RoughlyEnoughItems-default-plugin-fabric:${project.rei_version}"
 }
 
 processResources {
     inputs.property "version", project.version
     inputs.property "minecraft_version", project.minecraft_version
     inputs.property "loader_version", project.loader_version
+    inputs.property "rei_version", project.rei_version
     filteringCharset "UTF-8"
 
     filesMatching("fabric.mod.json") {
         expand "version": project.version,
                 "minecraft_version": project.minecraft_version,
-                "loader_version": project.loader_version
+                "loader_version": project.loader_version,
+                "rei_version": project.rei_version
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,9 +6,10 @@ minecraft_version=1.21.5
 yarn_mappings=1.21.5+build.1
 loader_version=0.16.14
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.0.2+1.21.5
 maven_group=me.BigBou
 archives_base_name=rei-search-bar-calculations
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
 fabric_version=0.128.0+1.21.5
+rei_version=19.0.806

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,6 +30,7 @@
   "depends": {
     "fabricloader": ">=${loader_version}",
     "fabric": "*",
-    "minecraft": "${minecraft_version}"
+    "minecraft": "${minecraft_version}",
+    "roughlyenoughitems": ">=${rei_version}"
   }
 }


### PR DESCRIPTION
REI is now on the dependency list so when people try to use the mod without REI installed they don't crash, they are told that they are missing REI.

Also added REI as a variable in gradle.properties to make it easier to update.